### PR TITLE
Fix failing threading test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 install:
   # Tools for checking coverage and uploading to coveralls
   - pip install coveralls coverage
-  - pip install cryptography<1.0.0 .
+  - pip install "cryptography<1.0.0" .
 
 script:
   - coverage run --branch --source=epsilon $(type -p trial) epsilon

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 install:
   # Tools for checking coverage and uploading to coveralls
   - pip install coveralls coverage
-  - pip install .
+  - pip install cryptography<1.0.0 .
 
 script:
   - coverage run --branch --source=epsilon $(type -p trial) epsilon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: "python"
 
 branches:


### PR DESCRIPTION
This test doesn't actually work with the reactor thread pool as of recently (it seems the pool isn't started, so only one thread runs, or something). Rewrite it to use a local thread pool, which is probably a better idea anyway.