### PR TITLE
Fix CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,16 @@ branches:
   only:
     - master
 
-python:
-  - 2.7
-
-env:
-  - TOXENV=py27
-  - TOXENV=pypy
+matrix:
+  include:
+    - python: 2.7.13
+      env: TOXENV=py27
+    - python: pypy2.7-5.8.0
+      env: TOXENV=pypy
 
 install:
   - pip install -U pip setuptools wheel
   - pip install tox codecov
-  - |
-    if [ "${TOXENV::4}" == "pypy" ]; then
-      git clone --depth 1 https://github.com/yyuu/pyenv.git ~/.pyenv
-      PYENV_ROOT="$HOME/.pyenv"
-      PATH="$PYENV_ROOT/bin:$PATH"
-      eval "$(pyenv init -)"
-      pyenv install pypy-5.4
-      pyenv global pypy-5.4
-    fi
 
 script:
   - tox

--- a/epsilon/scripts/benchmark.py
+++ b/epsilon/scripts/benchmark.py
@@ -377,12 +377,8 @@ def formatResults(name, sectorSize, before, after, error, timeout):
         read_ms = None
         write_ms = None
 
-    twisted_version = twisted.version._getSVNVersion()
-    if twisted_version is None:
-        twisted_version = twisted.version.short()
-    epsilon_version = epsilon.version._getSVNVersion()
-    if epsilon_version is None:
-        epsilon_version = epsilon.version.short()
+    twisted_version = twisted.version.short()
+    epsilon_version = epsilon.version.short()
 
     Results(
         version=STATS_VERSION,


### PR DESCRIPTION
A private API we were using in `twisted.python.version` has been removed, and we can now use Travis's pypy rather than getting our own via pyenv.