### PR TITLE
fix certcreate to work on python3

### DIFF
--- a/epsilon/scripts/certcreate.py
+++ b/epsilon/scripts/certcreate.py
@@ -38,7 +38,7 @@ def createSSLCertificate(opts):
         sslopt[y] = opts[x]
     serialNumber = int(opts['serial-number'])
     ssc = KeyPair.generate().selfSignedCert(serialNumber, **sslopt)
-    file(opts['filename'], 'w').write(ssc.dumpPEM())
+    open(opts['filename'], 'wb').write(ssc.dumpPEM())
     if not opts['quiet']:
         print('Wrote SSL certificate:')
         print(ssc.inspect())


### PR DESCRIPTION
use 'open' since 'file' hasn't been around for a decade now

fixes #39